### PR TITLE
chore: PD-7479: Potential fixes for 3 code scanning alerts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Help: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# Global owners
+* @Class-Foundations/developer-tools

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -17,6 +17,8 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -26,6 +28,8 @@ jobs:
 
   action:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -54,6 +58,9 @@ jobs:
     needs: [test, action]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   GIT_AUTHOR_NAME: github-actions[bot]
   GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
@@ -17,8 +20,6 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -28,8 +29,6 @@ jobs:
 
   action:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -60,7 +59,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -71,6 +69,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.16
+          cache: false
 
       - name: Next tag info
         id: tag

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Example for configuring all - `pip`, `npm/yarn1` and `yarn2+`:
 
 ```yaml
       - name: Setup Artifactory
-        uses: Class-Foundations/gh-action-setup-artifactory@v1
+        uses: Class-Foundations/gh-action-setup-artifactory@v2
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
@@ -25,7 +25,7 @@ Example for configuring only `pip`:
 
 ```yaml
       - name: Setup Artifactory
-        uses: Class-Foundations/gh-action-setup-artifactory@v1
+        uses: Class-Foundations/gh-action-setup-artifactory@v2
         env:
           ARTIFACTORY_SETUP_NPM: false
           ARTIFACTORY_YARN_SETUP: false
@@ -38,7 +38,7 @@ Example for configuring only `npm/yarn1`:
 
 ```yaml
       - name: Setup Artifactory
-        uses: Class-Foundations/gh-action-setup-artifactory@v1
+        uses: Class-Foundations/gh-action-setup-artifactory@v2
         env:
           ARTIFACTORY_SETUP_PIP: false
           ARTIFACTORY_YARN_SETUP: false
@@ -51,7 +51,7 @@ Example for configuring only `yarn2+`:
 
 ```yaml
       - name: Setup Artifactory
-        uses: blackboard-innersource/gh-action-setup-artifactory@v1
+        uses: blackboard-innersource/gh-action-setup-artifactory@v2
         env:
           ARTIFACTORY_SETUP_PIP: false
           ARTIFACTORY_SETUP_NPM: false


### PR DESCRIPTION
Potential fixes for 3 code scanning alerts from the [PD-7479: GH Actions workflow permissions](https://github.com/orgs/Class-Foundations/security/campaigns/1) security campaign:
- https://github.com/Class-Foundations/gh-action-setup-artifactory/security/code-scanning/3
To fix the issue, we will add a `permissions` block to the workflow. This block will define the minimal permissions required for each job. Specifically:
  1. The `test` and `action` jobs only need `contents: read` since they do not perform any write operations.
  2. The `cd` job requires additional permissions, such as `contents: write` for pushing tags and `packages: write` for creating releases.

  The `permissions` block will be added at the job level to ensure each job has only the permissions it needs.

  ---
  


- https://github.com/Class-Foundations/gh-action-setup-artifactory/security/code-scanning/2
To fix the issue, we will add a `permissions` block to the workflow. This block will specify the minimum required permissions for each job. Based on the workflow's actions, the following permissions are needed:
  - `contents: read` for accessing repository contents.
  - `contents: write` for creating tags and pushing changes in the `cd` job.
  - `actions: read` for downloading artifacts or listing workflows (if applicable).

  The `permissions` block will be added at the root level of the workflow to apply to all jobs. If specific jobs require additional permissions, we will override the root-level permissions with job-specific `permissions` blocks.

  ---
  


- https://github.com/Class-Foundations/gh-action-setup-artifactory/security/code-scanning/1
To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for each job. Based on the workflow's steps:
  - The `test` job only needs `contents: read` to check out the repository and run tests.
  - The `action` job also only needs `contents: read` for its steps.
  - The `cd` job requires `contents: write` to create tags and releases, and `actions: write` to interact with GitHub Actions.

  The `permissions` block can be added at the job level for each job to ensure the principle of least privilege is followed.

  ---
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
