### PR TITLE
fix(npm): modernize npm authentication [PD-8463]

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Example for configuring all - `pip`, `npm/yarn1` and `yarn2+`:
       - name: Setup Artifactory
         uses: Class-Foundations/gh-action-setup-artifactory@v2
         env:
-          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
+          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}  # Required for pip and yarn
+          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}        # JFrog Access Token
           ARTIFACTORY_PYPI_INDEX: ${{ secrets.ARTIFACTORY_PYPI_INDEX }}
           ARTIFACTORY_NPM_REGISTRY: ${{ secrets.ARTIFACTORY_NPM_REGISTRY }}
 ```
@@ -42,10 +42,11 @@ Example for configuring only `npm/yarn1`:
         env:
           ARTIFACTORY_SETUP_PIP: false
           ARTIFACTORY_YARN_SETUP: false
-          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
           ARTIFACTORY_NPM_REGISTRY: ${{ secrets.ARTIFACTORY_NPM_REGISTRY }}
 ```
+
+> **Note:** `ARTIFACTORY_TOKEN` should be a JFrog Access Token for npm authentication.
 
 Example for configuring only `yarn2+`:
 
@@ -60,6 +61,7 @@ Example for configuring only `yarn2+`:
 ```
 
 Additional environment variables:
+
 - `ARTIFACTORY_NPM_SCOPES` adds a scope to the NPM/yarn1 credential setup. Set multiple scopes with: `"@scope1,@scope2"`
   - DO NOT USE for yarn2+ - both repository and scopes should be configured in project's .yarnrc.yml file
 

--- a/setup_npm.sh
+++ b/setup_npm.sh
@@ -61,7 +61,6 @@ setup_npm() {
 $registry
 //${configKey}:_password=$(encode "$ARTIFACTORY_TOKEN")
 //${configKey}:username=$ARTIFACTORY_USERNAME
-//${configKey}:always-auth=true
 
 EOF
 

--- a/setup_npm.sh
+++ b/setup_npm.sh
@@ -29,7 +29,6 @@ setup_npm() {
     return 0
   fi
 
-  require_env "ARTIFACTORY_USERNAME" "$ARTIFACTORY_USERNAME" || return 1
   require_env "ARTIFACTORY_TOKEN" "$ARTIFACTORY_TOKEN" || return 1
   require_env "ARTIFACTORY_NPM_REGISTRY" "$ARTIFACTORY_NPM_REGISTRY" || return 1
 
@@ -59,8 +58,7 @@ setup_npm() {
 
   cat > "$npmrc" << EOF
 $registry
-//${configKey}:_password=$(encode "$ARTIFACTORY_TOKEN")
-//${configKey}:username=$ARTIFACTORY_USERNAME
+//${configKey}:_authToken=$ARTIFACTORY_TOKEN
 
 EOF
 

--- a/test/setup_npm.bats
+++ b/test/setup_npm.bats
@@ -33,7 +33,6 @@ function teardown {
 registry=https://example.com/test_registry/
 //example.com/test_registry/:_password=dGVzdF90b2tlbg==
 //example.com/test_registry/:username=test_username
-//example.com/test_registry/:always-auth=true
 EOF
 
 }
@@ -57,7 +56,6 @@ EOF
 @wakka:registry=https://example.com/test_registry/
 //example.com/test_registry/:_password=dGVzdF90b2tlbg==
 //example.com/test_registry/:username=test_username
-//example.com/test_registry/:always-auth=true
 EOF
 
 }

--- a/test/setup_npm.bats
+++ b/test/setup_npm.bats
@@ -19,7 +19,6 @@ function teardown {
 # shellcheck disable=SC2034
 @test "setup_npm can configure npm" {
   HOME="$TMPDIR"
-  ARTIFACTORY_USERNAME="test_username"
   ARTIFACTORY_TOKEN="test_token"
   ARTIFACTORY_NPM_REGISTRY="https://example.com/test_registry/"
 
@@ -31,8 +30,7 @@ function teardown {
   assert_success
   assert_output - <<EOF
 registry=https://example.com/test_registry/
-//example.com/test_registry/:_password=dGVzdF90b2tlbg==
-//example.com/test_registry/:username=test_username
+//example.com/test_registry/:_authToken=test_token
 EOF
 
 }
@@ -40,7 +38,6 @@ EOF
 # shellcheck disable=SC2034
 @test "setup_npm can configure npm with scopes" {
   HOME="$TMPDIR"
-  ARTIFACTORY_USERNAME="test_username"
   ARTIFACTORY_TOKEN="test_token"
   ARTIFACTORY_NPM_REGISTRY="https://example.com/test_registry/"
   ARTIFACTORY_NPM_SCOPES="@acme,@wakka"
@@ -54,8 +51,7 @@ EOF
   assert_output - <<EOF
 @acme:registry=https://example.com/test_registry/
 @wakka:registry=https://example.com/test_registry/
-//example.com/test_registry/:_password=dGVzdF90b2tlbg==
-//example.com/test_registry/:username=test_username
+//example.com/test_registry/:_authToken=test_token
 EOF
 
 }
@@ -78,7 +74,7 @@ EOF
   run setup_npm
   assert_failure
   assert [ ! -f "$TMPDIR/.npmrc" ]
-  assert_output "Missing env var 'ARTIFACTORY_USERNAME'"
+  assert_output "Missing env var 'ARTIFACTORY_TOKEN'"
 }
 
 # base64 on Linux wraps at 76 characters


### PR DESCRIPTION
## Summary

- Remove deprecated `always-auth=true` from generated `.npmrc` (causes warnings in npm 11+)
- Switch from `username/_password` to `_authToken` format for npm authentication

## Changes

- **setup_npm.sh**: Use `_authToken` instead of `_password`/`username`, remove `ARTIFACTORY_USERNAME` requirement for npm
- **test/setup_npm.bats**: Updated test assertions
- **README.md**: Clarified that `ARTIFACTORY_USERNAME` is only required for pip/yarn

## Test plan

- [x] Unit tests pass locally
- [x] Tested in GitHub Actions workflows
- [x] Tested in CodeBuild runs

🤖 Generated with [Claude Code](https://claude.ai/code)