### PR TITLE
fix(cd): use consistent svu pattern for current version

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -76,9 +76,10 @@ jobs:
         run: |
           go install github.com/caarlos0/svu@v1.5.0
           next=$(svu next --pattern 'v*.*.*')
-          echo "current: $(svu current)"
+          current=$(svu current --pattern 'v*.*.*')
+          echo "current: $current"
           echo "next:    $next"
-          echo "make=$(if [ "$next" = $(svu current) ]; then echo "0"; else echo "1"; fi)" >> $GITHUB_OUTPUT
+          echo "make=$(if [ "$next" = "$current" ]; then echo "0"; else echo "1"; fi)" >> $GITHUB_OUTPUT
           echo "next=$next" >> $GITHUB_OUTPUT
           echo ${next#"v"} > VERSION
 

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -79,9 +79,10 @@ jobs:
           current=$(svu current --pattern 'v*.*.*')
           echo "current: $current"
           echo "next:    $next"
-          echo "make=$(if [ "$next" = "$current" ]; then echo "0"; else echo "1"; fi)" >> $GITHUB_OUTPUT
-          echo "next=$next" >> $GITHUB_OUTPUT
-          echo ${next#"v"} > VERSION
+          if [ "$next" = "$current" ]; then make=0; else make=1; fi
+          echo "make=$make" >> "$GITHUB_OUTPUT"
+          echo "next=$next" >> "$GITHUB_OUTPUT"
+          echo "${next#v}" > VERSION
 
       - name: Version
         id: version


### PR DESCRIPTION
## Problem

The **CD Workflow** failed on the most recent push to `main` (run [#28012598814](https://github.com/Class-Foundations/gh-action-setup-artifactory/actions/runs/28012598814), PR #12) at the **Version** step:

```
✅ found v2.1.0 from VERSION file
🔥 git tag v2.1.0 already exists!
##[error]This version already exists, please bump accordingly.
```

## Root cause

The **Next tag info** step computed `next` and `current` with **inconsistent tag patterns**:

```bash
next=$(svu next --pattern 'v*.*.*')   # uses pattern  -> v2.1.0
echo "current: $(svu current)"        # NO pattern     -> v2.0.0 (!)
make=$(if [ "$next" = $(svu current) ]; then echo "0"; else echo "1"; fi)
```

When `v2.1.0` was released, the workflow's final step force-pushed a **major-only `v2` tag** onto the same commit. Without a `--pattern`, `svu current` falls back to `git describe --tags --abbrev=0`, which returns that `v2` tag — and svu parses `v2` as semver **`2.0.0`**, not the actual latest release `2.1.0`.

So on a non-bumping `chore:` commit (PR #12):
- `next` (with pattern) = `v2.1.0` (no bump for a chore)
- `current` (no pattern) = `v2.0.0` (stale, from the `v2` major tag)
- `make` = (`v2.1.0` ≠ `v2.0.0`) = **`1`** → tries to create `v2.1.0` → **collision**

It worked while `v2.0.0` was the latest release only because the `v2` tag coincidentally parsed to the same value as `next`.

## Fix

Compute `current` with the same `--pattern 'v*.*.*'` so the major-only tag is excluded and both invocations agree.

## Verification

Reproduced with `svu v1.5.0` against the repo's actual tags (matches the failed run's `current: v2.0.0 / next: v2.1.0`). With the fix, `current` resolves to `v2.1.0`, so `make` flips `1` → `0` and the release step is correctly skipped for chore-only commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)